### PR TITLE
ci: Add workflow for running e2e tests w/ text-embeddings

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,58 @@
+name: e2e
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "CODEOWNERS"
+      - ".gitignore"
+      - "docs/**"
+
+concurrency:
+  group: e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ai-ubuntu-big-boy-8-core 
+
+    steps:
+        - name: Checkout Repo
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+        - name: Setup Python
+          uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c #v5.0.0
+          with:
+            python-version-file: 'pyproject.toml'
+
+        - name: Install Python Deps
+          run: make requirements-dev
+
+        - name: Install UDS-CLI
+          run: |
+            wget https://github.com/defenseunicorns/uds-cli/releases/download/v0.9.2/uds-cli_v0.9.2_Linux_amd64
+            chmod +x uds-cli_v0.9.2_Linux_amd64
+            sudo mv uds-cli_v0.9.2_Linux_amd64 /usr/local/bin/uds
+
+        - name: Setup K3D
+          run: |
+            wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.6.0 bash
+          
+        - name: Create UDS Cluster
+          run: |
+            uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-istio-dev:0.13.1 --confirm
+
+        - name: Install lfai-api 
+          run: |
+            uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai-api:v0.5.1 --confirm
+
+        # Since Zarf is slow when using local images, we are pushing the embeddings image to a local registry
+        - name: Build & Deploy Embeddings 
+          run: |
+            docker run -d -p 5000:5000 --restart=always --name registry registry:2
+            docker build -t localhost:5000/defenseunicorns/leapfrogai/text-embeddings:e2e-amd64 .
+            docker push localhost:5000/defenseunicorns/leapfrogai/text-embeddings:e2e-amd64 
+            uds zarf dev deploy --registry-override=ghcr.io=localhost:5000 --create-set=IMAGE_VERSION=e2e-amd64 --no-yolo
+
+        - name: Run Tests
+          run: |
+            python -m pytest ./tests/e2e -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pip-tools", "pytest", "black", "isort"]
+dev = ["pip-tools", "pytest", "black", "isort", "openai"]
 
 [tool.pip-tools]
 generate-hashes = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,12 @@
 #
 #    pip-compile --extra=dev --generate-hashes --output-file=requirements-dev.txt pyproject.toml
 #
+anyio==4.3.0 \
+    --hash=sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8 \
+    --hash=sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6
+    # via
+    #   httpx
+    #   openai
 black==23.9.1 \
     --hash=sha256:031e8c69f3d3b09e1aa471a926a1eeb0b9071f80b17689a655f7885ac9325a6f \
     --hash=sha256:13a2e4a93bb8ca74a749b6974925c27219bb3df4d42fc45e948a5d9feb5122b7 \
@@ -35,7 +41,10 @@ build==1.0.3 \
 certifi==2023.11.17 \
     --hash=sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1 \
     --hash=sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474
-    # via requests
+    # via
+    #   httpcore
+    #   httpx
+    #   requests
 charset-normalizer==3.3.2 \
     --hash=sha256:06435b539f889b1f6f4ac1758871aae42dc3a8c0e24ac9e60c2384973ad73027 \
     --hash=sha256:06a81e93cd441c56a9b65d8e1d043daeb97a3d0856d177d5c90ba85acb3db087 \
@@ -140,6 +149,10 @@ confz==2.0.1 \
     --hash=sha256:271dfbc7343dafda414f731c4931ba91bc62a448e4a3b2fdf2fb7334ffac1d36 \
     --hash=sha256:c2d7af28224d8e70c72f66c4ea7ca0069abdc73dda11732d74f2be7dbe8641a0
     # via leapfrogai
+distro==1.9.0 \
+    --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
+    --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
+    # via openai
 filelock==3.13.1 \
     --hash=sha256:521f5f56c50f8426f5e03ad3b281b490a87ef15bc6c526f168290f0c7148d44e \
     --hash=sha256:57dbda9b35157b05fb3e58ee91448612eb674172fab98ee235ccb0b5bee19a1c
@@ -221,6 +234,18 @@ grpcio-reflection==1.59.0 \
     --hash=sha256:1fe8f0dd6c180fdcf4e12ced2a8f784d9c741ccbc0b198585b1df024b7f8f3f2 \
     --hash=sha256:bf4efc7e2e8162e5be9736f4d0a0b324c9bf0c04ad597a9d78fcaf1fbdf818ec
     # via leapfrogai
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
+    # via httpcore
+httpcore==1.0.4 \
+    --hash=sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73 \
+    --hash=sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022
+    # via httpx
+httpx==0.27.0 \
+    --hash=sha256:71d5465162c13681bff01ad59b2cc68dd838ea1f10e51574bac27103f00c91a5 \
+    --hash=sha256:a0cb88a46f32dc874e04ee956e4c2764aba2aa228f650b06788ba6bda2962ab5
+    # via openai
 huggingface-hub==0.20.2 \
     --hash=sha256:215c5fceff631030c7a3d19ba7b588921c908b3f21eef31d160ebc245b200ff6 \
     --hash=sha256:53752eda2239d30a470c307a61cf9adcf136bc77b0a734338c7d04941af560d8
@@ -231,7 +256,10 @@ huggingface-hub==0.20.2 \
 idna==3.6 \
     --hash=sha256:9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca \
     --hash=sha256:c05567e9c24a6b9faaa835c4821bad0590fbb9d5779e7caa6e1cc4978e7eb24f
-    # via requests
+    # via
+    #   anyio
+    #   httpx
+    #   requests
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
@@ -435,6 +463,10 @@ nvidia-nvtx-cu12==12.1.105 \
     --hash=sha256:65f4d98982b31b60026e0e6de73fbdfc09d08a96f4656dd3665ca616a11e1e82 \
     --hash=sha256:dc21cf308ca5691e7c04d962e213f8a4aa9bbfa23d95412f452254c2caeb09e5
     # via torch
+openai==1.13.3 \
+    --hash=sha256:5769b62abd02f350a8dd1a3a242d8972c947860654466171d60fb0972ae0a41c \
+    --hash=sha256:ff6c6b3bc7327e715e4b3592a923a5a1c7519ff5dd764a83d69f633d49e77a7b
+    # via leapfrogai-backend-embeddings (pyproject.toml)
 packaging==23.2 \
     --hash=sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5 \
     --hash=sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7
@@ -590,6 +622,7 @@ pydantic==1.10.14 \
     # via
     #   confz
     #   leapfrogai
+    #   openai
 pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
@@ -996,6 +1029,13 @@ sentencepiece==0.1.99 \
     --hash=sha256:fa16a830416bb823fa2a52cbdd474d1f7f3bba527fd2304fb4b140dad31bb9bc \
     --hash=sha256:fb71af492b0eefbf9f2501bec97bcd043b6812ab000d119eaf4bd33f9e283d03
     # via sentence-transformers
+sniffio==1.3.1 \
+    --hash=sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2 \
+    --hash=sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc
+    # via
+    #   anyio
+    #   httpx
+    #   openai
 sympy==1.12 \
     --hash=sha256:c3588cd4295d0c0f603d0f2ae780587e64e2efeedb3521e46b9bb1d08d184fa5 \
     --hash=sha256:ebf595c8dac3e0fdc4152c51878b498396ec7f30e7a914d6071e674d49420fb8
@@ -1174,6 +1214,7 @@ tqdm==4.66.1 \
     #   huggingface-hub
     #   leapfrogai-backend-embeddings (pyproject.toml)
     #   nltk
+    #   openai
     #   sentence-transformers
     #   transformers
 transformers==4.36.0 \
@@ -1197,6 +1238,7 @@ typing-extensions==4.8.0 \
     --hash=sha256:df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef
     # via
     #   huggingface-hub
+    #   openai
     #   pydantic
     #   torch
 urllib3==2.0.7 \

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,39 @@
+# Text-Embeddings End-To-End Tests
+
+This directory holds our e2e tests that we use to verify LFAI + Text-Embeddings functionality in an environment that replicates a live setting. The tests in this directory are automatically run against a [UDS Core](https://github.com/defenseunicorns/uds-core) cluster whenever a PR is opened or updated.
+
+
+## Running Tests Locally
+The tests in this directory are also able to be run locally! We are currently opinionated towards running on a cluster that is configured with UDS, as we mature out tests & documentations we'll potentially lose some of that opinionation.
+
+
+### Dependencies
+1. Python >= 3.11.6
+2. k3d >= v5.6.0
+3. uds >= v0.7.0
+
+
+### Actually Running The Test
+There are several ways you can setup and run these tests. Here is one such way:
+
+```bash
+# Setup the UDS cluster
+# NOTE: This stands up a k3d cluster and installs istio & pepr
+# NOTE: Be sure to use the latest released version at the time you're reading this!
+uds deploy oci://ghcr.io/defenseunicorns/packages/uds/bundles/k3d-core-istio-dev:0.13.1 --confirm
+
+# Install the LFAI API
+# NOTE: Be sure to use the latest released version at the time you're reading this!
+uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai-api:v0.5.1 --confirm
+
+# Install the Text-Embeddings Backend
+# NOTE: Be sure to use the latest released version at the time you're reading this!
+# NOTE: If you are testing changes you have made locally, you will need to rebuild the Text-Embeddings Docker image and Zarf Package.
+uds zarf package deploy oci://ghcr.io/defenseunicorns/packages/leapfrogai/Text-Embeddings:0.1.0 --confirm
+
+# Install the python dependencies
+python -m pip install -r requirements-dev.txt
+
+# Run the tests!
+python -m pytest .  -v
+```

--- a/tests/e2e/test_e2e.py
+++ b/tests/e2e/test_e2e.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+import pytest
+from openai import InternalServerError, OpenAI
+
+client = OpenAI(
+    base_url="https://leapfrogai-api.uds.dev/openai/v1",
+    api_key="Free the models",
+)
+
+model_name = "text-embeddings"
+
+
+def test_completions():
+    with pytest.raises(InternalServerError) as excinfo:
+        client.completions.create(
+            model=model_name,
+            prompt="This should result in a failure",
+        )
+    assert str(excinfo.value) == "Internal Server Error"
+
+
+def test_chat_completions():
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "This should result in a failure"},
+    ]
+
+    with pytest.raises(InternalServerError) as excinfo:
+        client.chat.completions.create(model=model_name, messages=messages)
+    assert str(excinfo.value) == "Internal Server Error"
+
+
+def test_embeddings():
+    embedding_response = client.embeddings.create(
+        model=model_name,
+        input="This should result in a failure",
+    )
+
+    assert embedding_response.model == model_name
+    assert len(embedding_response.data) > 0
+    assert len(embedding_response.data[0].embedding) > 0
+    assert len(embedding_response.data[0].embedding) < 1000
+
+
+def test_transcriptions():
+    with pytest.raises(InternalServerError) as excinfo:
+        client.audio.transcriptions.create(
+            model=model_name, file=Path("tests/e2e/README.md")
+        )
+    assert str(excinfo.value) == "Internal Server Error"

--- a/zarf-config.yaml
+++ b/zarf-config.yaml
@@ -5,3 +5,9 @@ package:
       image_version: 0.2.0
       name: text-embeddings
     max_package_size: "1000000000"
+  deploy:
+    set:
+      requests_memory: "0"
+      requests_cpu: "0"
+      limits_memory: "0"
+      limits_cpu: "0"


### PR DESCRIPTION
This PR introduces an e2e test that verifies the text-embeddings backend can be deployed onto a UDS cluster with LFAI-API and functions as expected.